### PR TITLE
fix(auth): enable authentication through Pollination App login

### DIFF
--- a/src/PollinationSDK/Helper/AuthHelper.cs
+++ b/src/PollinationSDK/Helper/AuthHelper.cs
@@ -12,10 +12,8 @@ namespace PollinationSDK
     public static class AuthHelper
     {
 
-        private static string Auth0ClientID_GH => "Q566EJGvOncgZIQRDzxHrxBsG4TXCGrR";
-        private static string Auth0ClientID_GH_Dev => "aky7VQoGmXA5QgWYSLmCGAb67Xm5Wzhu";
-        private static string Auth0URL => "https://pollination.auth0.com/";
-        private static string Auth0URL_Dev => "https://pollination-staging.auth0.com/";
+        private static string LoginURL => "https://app.pollination.cloud/sdk-login";
+        private static string LoginURL_Dev => "https://app.staging.pollination.cloud/sdk-login";
 
         private static string ApiURL => "https://api.pollination.cloud/";
         private static string ApiURL_Dev => "https://api.staging.pollination.cloud/";
@@ -27,7 +25,7 @@ namespace PollinationSDK
         public static async Task SignInAsync(Action ActionWhenDone = default, bool devEnv = false)
         {
             //OutputMessage = string.Empty;
-            var task = Auth0SignIn(devEnv);
+            var task = PollinationSignIn(devEnv);
             try
             {
                 var token = await task;
@@ -49,29 +47,19 @@ namespace PollinationSDK
                 throw;
             }
 
-
-
-
         }
 
-        public static async Task<string> Auth0SignIn(bool devEnv = false)
+        public static async Task<string> PollinationSignIn(bool devEnv = false)
         {
+            var redirectUrl = "http://localhost:8645/";
+            var loginUrl = devEnv ? LoginURL_Dev : LoginURL;
 
-            // create a redirect URI using an available port on the loopback address.
-            //string redirectUri = string.Format("https://app.pollination.cloud/callback");
-            string redirectUri = string.Format("http://localhost:3000/");
-            Console.WriteLine("redirect URI: " + redirectUri);
-            Console.WriteLine("-----------------------------------");
-
-
-
-            // create an HttpListener to listen for requests on that redirect URI.
             var listener = new System.Net.HttpListener();
+
             try
             {
-                listener.Prefixes.Add(redirectUri);
-                listener.Start(); 
-                Console.WriteLine($"Listening..{redirectUri}");
+                listener.Prefixes.Add(redirectUrl);
+                listener.Start();
 
             }
             catch (HttpListenerException e)
@@ -86,40 +74,10 @@ namespace PollinationSDK
                 throw;
 
             }
-           
-
-
-            var verifier = GenVerifier();
-            var codeChallenge = GenCodeChallenge(verifier);
-            //var verifier = state.CodeVerifier;
-            Console.WriteLine("Verifier: " + verifier);
-            Console.WriteLine("-----------------------------------");
-
-            var state = GenState();
-            Console.WriteLine("state: " + state);
-
-
-            //var loginURL = state.StartUrl;
-            // Build URL
-
-            var authUrl = devEnv ? Auth0URL_Dev : Auth0URL;
-            var authClientID = devEnv ? Auth0ClientID_GH_Dev : Auth0ClientID_GH;
-
-            var loginURL = authUrl;
-            loginURL += $"authorize?response_type=code";
-            loginURL += $"&code_challenge={codeChallenge}";
-            loginURL += $"&code_challenge_method=S256";
-            loginURL += $"&client_id={authClientID}";
-            loginURL += $"&scope=openid";
-            loginURL += $"&redirect_uri={redirectUri}";
-            loginURL += $"&state={state}";
-
-
-            Console.WriteLine($"Start login URL: {loginURL}");
 
             var psi = new System.Diagnostics.ProcessStartInfo
             {
-                FileName = loginURL,
+                FileName = loginUrl,
                 UseShellExecute = true
             };
             System.Diagnostics.Process.Start(psi);
@@ -130,96 +88,19 @@ namespace PollinationSDK
             var request = context.Request;
             var response = context.Response;
 
-
-            Console.WriteLine("-----------------------------------");
-            //Console.WriteLine($"AUTHORIZATION_CODE: ");
-            var returnUrl = request.RawUrl.Contains("?code=") ? request.RawUrl : request.UrlReferrer?.PathAndQuery;
+            var returnUrl = request.RawUrl.Contains("?token=") ? request.RawUrl : request.UrlReferrer?.PathAndQuery;
             if (string.IsNullOrEmpty(returnUrl)) throw new ArgumentException($"Failed to authorize the login: \n{request.RawUrl}");
-            var AUTHORIZATION_CODE = returnUrl.Split('&').FirstOrDefault(_ => _.StartsWith("/?code=")).Split('=').Last().Trim();
-            //Console.WriteLine(AUTHORIZATION_CODE);
-
-            //Console.WriteLine($"State: ");
-            var returnState = request.RawUrl.Split('&').FirstOrDefault(_ => _.StartsWith("state=")).Split('=').Last().Trim();
-            //Console.WriteLine(returnState);
-            var IsAuthorized = returnState.Equals(state);
-            IsAuthorized &= !string.IsNullOrEmpty(AUTHORIZATION_CODE);
-            Console.WriteLine($"IsAuthorized: {IsAuthorized}");
-            Console.WriteLine("-----------------------------------");
-
-            var responseMessage = "This is not an authorized request!";
-
-            // Request Tokens
-            if (IsAuthorized)
-            {
-                var restClient = new RestClient($"{authUrl}oauth/token");
-                var restRequest = new RestRequest( Method.POST);
-                //restRequest.AddHeader("Content-Type", "application/x-www-form-urlencoded");
-                restRequest.AddParameter(
-                    "application/x-www-form-urlencoded", 
-                    $"grant_type=authorization_code&client_id={authClientID}&code_verifier={verifier}&code={AUTHORIZATION_CODE}&redirect_uri={redirectUri}", 
-                    ParameterType.RequestBody
-                    );
-        
-                var restResponse = restClient.Execute(restRequest);
-                if (restResponse.StatusCode == HttpStatusCode.OK)
-                {
-                    var responseContent = restResponse.Content;
-                    var id_token = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(responseContent)["id_token"].ToString();
-                    ID_TOKEN = id_token;
-                    Console.WriteLine("Successful login!");
-                    //Console.WriteLine("id_token: " + id_token);
-                    Console.WriteLine("-----------------------------------");
-                    responseMessage = "Signed in!. \n\nYou can close this window, and return to the Grasshopper.";
-
-                }
-
-
-            }
 
             //sends an HTTP response to the browser.
-            string responseString = string.Format($"<html><head></head><body>{responseMessage}</body></html>");
+            string responseString = string.Format($"<html><head></head><body>Succesfully Logged in! You can close this browser window.</body></html>");
             var buffer = Encoding.UTF8.GetBytes(responseString);
             response.ContentLength64 = buffer.Length;
             var responseOutput = response.OutputStream;
-            await responseOutput.WriteAsync(buffer, 0, buffer.Length);
+            responseOutput.Write(buffer, 0, buffer.Length);
             responseOutput.Close();
 
-            listener.Stop();
 
-            return ID_TOKEN;
-
-        }
-
-        public static string GenVerifier() => GenCode(32);
-        public static string GenState() => GenCode(16);
-
-        public static string GenCode(int length)
-        {
-            Random rnd = new Random();
-            Byte[] b = new Byte[length];
-            rnd.NextBytes(b);
-            var verifier = Base64UrlEncode(b);
-            return verifier;
-        }
-        public static string GenCodeChallenge(string verifier)
-        {
-            var sha256 = System.Security.Cryptography.SHA256.Create();
-            var bytes = sha256.ComputeHash(Encoding.ASCII.GetBytes(verifier));
-            var codeChallenge = Base64UrlEncode(bytes);
-            return codeChallenge;
-
-        }
-
-        private static string Base64UrlEncode(Byte[] inputBytes)
-        {
-            var encoded = Convert.ToBase64String(inputBytes)
-                .TrimEnd(new[] { '=' })
-                .Replace('+', '-')
-                .Replace('/', '_')
-                .Replace("=", "");
-            return encoded;
+            return returnUrl.Split('=').LastOrDefault();
         }
     }
-
-
 }


### PR DESCRIPTION
This change demonstrates how we can authenticate using the `/sdk-login` endpoint on the Pollination App. I am not sure whether this code is meant to be auto-generated or if you are happy merging this in just now. It's worth noting that you probably want to wait until we have fully migrated staging and production before using this version of the authentication mechanism.

PS: sorry for making a branch on this repo! I got confused when using git on Windows 🙃