### PR TITLE
fix(AuthHelper): Use auth app and token refresh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,8 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends python3 default-jre
+    && apt-get -y install --no-install-recommends python3 default-jre \
+    && apt-get install git
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,48 +1,46 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/dotnet
 {
-	"name": "C# (.NET)",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
-			"VARIANT": "3.1",
-			// Options
-			"NODE_VERSION": "lts/*"
-		}
-	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-dotnettools.csharp"
-	],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [5000, 5001],
-	// [Optional] To reuse of your local HTTPS dev cert:
-	//
-	// 1. Export it locally using this command:
-	//    * Windows PowerShell:
-	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
-	//    * macOS/Linux terminal:
-	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
-	// 
-	// 2. Uncomment these 'remoteEnv' lines:
-	//    "remoteEnv": {
-	// 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
-	//        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
-	//    },
-	//
-	// 3. Do one of the following depending on your scenario:
-	//    * When using GitHub Codespaces and/or Remote - Containers:
-	//      1. Start the container
-	//      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
-	//      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
-	//
-	//    * If only using Remote - Containers with a local container, uncomment this line instead:
-	//      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "dotnet restore",
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+  "name": "C# (.NET)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+      "VARIANT": "3.1",
+      // Options
+      "NODE_VERSION": "lts/*"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["ms-dotnettools.csharp", "eamodio.gitlens"],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [5000, 5001],
+  // [Optional] To reuse of your local HTTPS dev cert:
+  //
+  // 1. Export it locally using this command:
+  //    * Windows PowerShell:
+  //        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  //    * macOS/Linux terminal:
+  //        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  //
+  // 2. Uncomment these 'remoteEnv' lines:
+  //    "remoteEnv": {
+  // 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+  //        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+  //    },
+  //
+  // 3. Do one of the following depending on your scenario:
+  //    * When using GitHub Codespaces and/or Remote - Containers:
+  //      1. Start the container
+  //      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+  //      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+  //
+  //    * If only using Remote - Containers with a local container, uncomment this line instead:
+  //      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "dotnet restore",
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
 }

--- a/.openapi-generator/templates/csharp/ApiClient.mustache
+++ b/.openapi-generator/templates/csharp/ApiClient.mustache
@@ -27,6 +27,64 @@ using RestSharp;
 namespace {{packageName}}.Client
 {
     /// <summary>
+    /// TokenRepo is responsible for holding and acquiring auth tokens
+    /// </summary>
+    {{>visibility}} class TokenRepo
+    {
+        public string RefreshURL;
+        private string IDToken;
+        public DateTime ExpiresAt;
+        public string RefreshToken;
+
+        public TokenRepo(string refreshURL, string idToken, int expiresInSeconds, string refreshToken)
+        {
+            RefreshURL = refreshURL;
+            IDToken = idToken;
+            ExpiresAt = DateTime.Now.AddSeconds(expiresInSeconds);
+            RefreshToken = refreshToken;
+        }
+
+        private async System.Threading.Tasks.Task RefreshTokenAsync()
+        {
+
+            var client = new RestClient(this.RefreshURL);
+
+            var req = new RestRequest().AddJsonBody(
+                new Dictionary<string, string>
+                {
+                    {
+                        "token", this.RefreshToken }
+                    }
+                );
+
+            var res = await client.PostAsync<Dictionary<string, string>>(req);
+
+            string detail = null;
+
+            res.TryGetValue("detail", out detail);
+
+            if (detail != null)
+            {
+                throw new Exception(detail);
+            }
+
+            this.IDToken = res["id_token"];
+            this.ExpiresAt = DateTime.Now.AddSeconds(int.Parse(res["expires_in"]));
+            this.RefreshToken = res["refresh_token"];
+        }
+
+        public async System.Threading.Tasks.Task<string> GetToken()
+        {
+            if (DateTime.Now >= this.ExpiresAt)
+            {
+                await this.RefreshTokenAsync();
+            }
+
+            return this.IDToken;
+        }
+    }
+
+    /// <summary>
     /// API client is mainly responsible for making the HTTP call to the API backend.
     /// </summary>
     {{>visibility}} partial class ApiClient
@@ -582,7 +640,7 @@ namespace {{packageName}}.Client
         {{/netStandard}}
 
         /// <summary>
-        /// Convert params to key/value pairs. 
+        /// Convert params to key/value pairs.
         /// Use collectionFormat to properly format lists and collections.
         /// </summary>
         /// <param name="collectionFormat">Collection format.</param>

--- a/.openapi-generator/templates/csharp/ApiClient.mustache
+++ b/.openapi-generator/templates/csharp/ApiClient.mustache
@@ -27,64 +27,6 @@ using RestSharp;
 namespace {{packageName}}.Client
 {
     /// <summary>
-    /// TokenRepo is responsible for holding and acquiring auth tokens
-    /// </summary>
-    {{>visibility}} class TokenRepo
-    {
-        public string RefreshURL;
-        private string IDToken;
-        public DateTime ExpiresAt;
-        public string RefreshToken;
-
-        public TokenRepo(string refreshURL, string idToken, int expiresInSeconds, string refreshToken)
-        {
-            RefreshURL = refreshURL;
-            IDToken = idToken;
-            ExpiresAt = DateTime.Now.AddSeconds(expiresInSeconds);
-            RefreshToken = refreshToken;
-        }
-
-        private async System.Threading.Tasks.Task RefreshTokenAsync()
-        {
-
-            var client = new RestClient(this.RefreshURL);
-
-            var req = new RestRequest().AddJsonBody(
-                new Dictionary<string, string>
-                {
-                    {
-                        "token", this.RefreshToken }
-                    }
-                );
-
-            var res = await client.PostAsync<Dictionary<string, string>>(req);
-
-            string detail = null;
-
-            res.TryGetValue("detail", out detail);
-
-            if (detail != null)
-            {
-                throw new Exception(detail);
-            }
-
-            this.IDToken = res["id_token"];
-            this.ExpiresAt = DateTime.Now.AddSeconds(int.Parse(res["expires_in"]));
-            this.RefreshToken = res["refresh_token"];
-        }
-
-        public async System.Threading.Tasks.Task<string> GetToken()
-        {
-            if (DateTime.Now >= this.ExpiresAt)
-            {
-                await this.RefreshTokenAsync();
-            }
-
-            return this.IDToken;
-        }
-    }
-
-    /// <summary>
     /// API client is mainly responsible for making the HTTP call to the API backend.
     /// </summary>
     {{>visibility}} partial class ApiClient

--- a/.openapi-generator/templates/csharp/Configuration.mustache
+++ b/.openapi-generator/templates/csharp/Configuration.mustache
@@ -48,6 +48,7 @@ namespace {{packageName}}.Client
             string detail = null;
 
             res.TryGetValue("detail", out detail);
+            res.TryGetValue("message", out detail);
 
             if (detail != null)
             {
@@ -354,7 +355,11 @@ namespace {{packageName}}.Client
         {
             get
             {
-                return TokenRepo.GetToken().Result;
+                if (TokenRepo != null)
+                {
+                    return TokenRepo.GetToken().Result;
+                }
+                return "";
             }
         }
 

--- a/.openapi-generator/templates/csharp/Configuration.mustache
+++ b/.openapi-generator/templates/csharp/Configuration.mustache
@@ -47,8 +47,8 @@ namespace {{packageName}}.Client
 
             string detail = null;
 
-            res.TryGetValue("detail", out detail);
-            res.TryGetValue("message", out detail);
+            res.TryGetValue("detail", out detail); // A Pollination error occurred
+            res.TryGetValue("message", out detail); // A Firebase error occurred
 
             if (detail != null)
             {

--- a/.openapi-generator/templates/csharp/Configuration.mustache
+++ b/.openapi-generator/templates/csharp/Configuration.mustache
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using RestSharp;
 
 namespace {{packageName}}.Client
 {
@@ -152,6 +153,12 @@ namespace {{packageName}}.Client
         private string _tempFolderPath = Path.GetTempPath();
 
         #endregion Private Members
+
+        #region Public Members
+
+        public TokenRepo TokenRepo;
+
+        #endregion
 
         #region Constructors
 
@@ -343,7 +350,13 @@ namespace {{packageName}}.Client
         /// Gets or sets the access token for OAuth2 authentication.
         /// </summary>
         /// <value>The access token.</value>
-        public virtual string AccessToken { get; set; }
+        public virtual string AccessToken
+        {
+            get
+            {
+                return TokenRepo.GetToken().Result;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the temporary folder path to store the files downloaded from the server.

--- a/.openapi-generator/templates/csharp/Configuration.mustache
+++ b/.openapi-generator/templates/csharp/Configuration.mustache
@@ -1,0 +1,511 @@
+{{>partial_header}}
+using System;
+using System.Reflection;
+{{^net35}}
+using System.Collections.Concurrent;
+{{/net35}}
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// TokenRepo is responsible for holding and acquiring auth tokens
+    /// </summary>
+    {{>visibility}} class TokenRepo
+    {
+        public string RefreshURL;
+        private string IDToken;
+        public DateTime ExpiresAt;
+        public string RefreshToken;
+
+        public TokenRepo(string refreshURL, string idToken, int expiresInSeconds, string refreshToken)
+        {
+            RefreshURL = refreshURL;
+            IDToken = idToken;
+            ExpiresAt = DateTime.Now.AddSeconds(expiresInSeconds);
+            RefreshToken = refreshToken;
+        }
+
+        private async System.Threading.Tasks.Task RefreshTokenAsync()
+        {
+
+            var client = new RestClient(this.RefreshURL);
+
+            var req = new RestRequest().AddJsonBody(
+                new Dictionary<string, string>
+                {
+                    {
+                        "token", this.RefreshToken }
+                    }
+                );
+
+            var res = await client.PostAsync<Dictionary<string, string>>(req);
+
+            string detail = null;
+
+            res.TryGetValue("detail", out detail);
+
+            if (detail != null)
+            {
+                throw new Exception(detail);
+            }
+
+            this.IDToken = res["id_token"];
+            this.ExpiresAt = DateTime.Now.AddSeconds(int.Parse(res["expires_in"]));
+            this.RefreshToken = res["refresh_token"];
+        }
+
+        public async System.Threading.Tasks.Task<string> GetToken()
+        {
+            if (DateTime.Now >= this.ExpiresAt)
+            {
+                await this.RefreshTokenAsync();
+            }
+
+            return this.IDToken;
+        }
+    }
+
+    /// <summary>
+    /// Represents a set of configuration settings
+    /// </summary>
+    {{>visibility}} class Configuration : IReadableConfiguration
+    {
+        #region Constants
+
+        /// <summary>
+        /// Version of the package.
+        /// </summary>
+        /// <value>Version of the package.</value>
+        public const string Version = "{{packageVersion}}";
+
+        /// <summary>
+        /// Identifier for ISO 8601 DateTime Format
+        /// </summary>
+        /// <remarks>See https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8 for more information.</remarks>
+        // ReSharper disable once InconsistentNaming
+        public const string ISO8601_DATETIME_FORMAT = "o";
+
+        #endregion Constants
+
+        #region Static Members
+
+        private static readonly object GlobalConfigSync = new { };
+        private static Configuration _globalConfiguration;
+
+        /// <summary>
+        /// Default creation of exceptions for a given method name and response object
+        /// </summary>
+        public static readonly ExceptionFactory DefaultExceptionFactory = (methodName, response) =>
+        {
+            var status = (int)response.StatusCode;
+            if (status >= 400)
+            {
+                return new ApiException(status,
+                    string.Format("Error calling {0}: {1}", methodName, response.Content),
+                    response.Content);
+            }
+            {{^netStandard}}if (status == 0)
+            {
+                return new ApiException(status,
+                    string.Format("Error calling {0}: {1}", methodName, response.ErrorMessage), response.ErrorMessage);
+            }{{/netStandard}}
+            return null;
+        };
+
+        /// <summary>
+        /// Gets or sets the default Configuration.
+        /// </summary>
+        /// <value>Configuration.</value>
+        public static Configuration Default
+        {
+            get { return _globalConfiguration; }
+            set
+            {
+                lock (GlobalConfigSync)
+                {
+                    _globalConfiguration = value;
+                }
+            }
+        }
+
+        #endregion Static Members
+
+        #region Private Members
+
+        /// <summary>
+        /// Gets or sets the API key based on the authentication name.
+        /// </summary>
+        /// <value>The API key.</value>
+        private IDictionary<string, string> _apiKey = null;
+
+        /// <summary>
+        /// Gets or sets the prefix (e.g. Token) of the API key based on the authentication name.
+        /// </summary>
+        /// <value>The prefix of the API key.</value>
+        private IDictionary<string, string> _apiKeyPrefix = null;
+
+        private string _dateTimeFormat = ISO8601_DATETIME_FORMAT;
+        private string _tempFolderPath = Path.GetTempPath();
+
+        #endregion Private Members
+
+        #region Constructors
+
+        static Configuration()
+        {
+            _globalConfiguration = new GlobalConfiguration();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Configuration" /> class
+        /// </summary>
+        public Configuration()
+        {
+            UserAgent = "{{httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{packageVersion}}/csharp{{/httpUserAgent}}";
+            BasePath = "{{{basePath}}}";
+            DefaultHeader = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
+            ApiKey = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
+            ApiKeyPrefix = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
+
+            // Setting Timeout has side effects (forces ApiClient creation).
+            Timeout = 100000;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Configuration" /> class
+        /// </summary>
+        public Configuration(
+            IDictionary<string, string> defaultHeader,
+            IDictionary<string, string> apiKey,
+            IDictionary<string, string> apiKeyPrefix,
+            string basePath = "{{{basePath}}}") : this()
+        {
+            if (string.{{^net35}}IsNullOrWhiteSpace{{/net35}}{{#net35}}IsNullOrEmpty{{/net35}}(basePath))
+                throw new ArgumentException("The provided basePath is invalid.", "basePath");
+            if (defaultHeader == null)
+                throw new ArgumentNullException("defaultHeader");
+            if (apiKey == null)
+                throw new ArgumentNullException("apiKey");
+            if (apiKeyPrefix == null)
+                throw new ArgumentNullException("apiKeyPrefix");
+
+            BasePath = basePath;
+
+            foreach (var keyValuePair in defaultHeader)
+            {
+                DefaultHeader.Add(keyValuePair);
+            }
+
+            foreach (var keyValuePair in apiKey)
+            {
+                ApiKey.Add(keyValuePair);
+            }
+
+            foreach (var keyValuePair in apiKeyPrefix)
+            {
+                ApiKeyPrefix.Add(keyValuePair);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Configuration" /> class with different settings
+        /// </summary>
+        /// <param name="apiClient">Api client</param>
+        /// <param name="defaultHeader">Dictionary of default HTTP header</param>
+        /// <param name="username">Username</param>
+        /// <param name="password">Password</param>
+        /// <param name="accessToken">accessToken</param>
+        /// <param name="apiKey">Dictionary of API key</param>
+        /// <param name="apiKeyPrefix">Dictionary of API key prefix</param>
+        /// <param name="tempFolderPath">Temp folder path</param>
+        /// <param name="dateTimeFormat">DateTime format string</param>
+        /// <param name="timeout">HTTP connection timeout (in milliseconds)</param>
+        /// <param name="userAgent">HTTP user agent</param>
+        [Obsolete("Use explicit object construction and setting of properties.", true)]
+        public Configuration(
+            // ReSharper disable UnusedParameter.Local
+            ApiClient apiClient = null,
+            IDictionary<string, string> defaultHeader = null,
+            string username = null,
+            string password = null,
+            string accessToken = null,
+            IDictionary<string, string> apiKey = null,
+            IDictionary<string, string> apiKeyPrefix = null,
+            string tempFolderPath = null,
+            string dateTimeFormat = null,
+            int timeout = 100000,
+            string userAgent = "{{httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{packageVersion}}/csharp{{/httpUserAgent}}"
+            // ReSharper restore UnusedParameter.Local
+            )
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Configuration class.
+        /// </summary>
+        /// <param name="apiClient">Api client.</param>
+        [Obsolete("This constructor caused unexpected sharing of static data. It is no longer supported.", true)]
+        // ReSharper disable once UnusedParameter.Local
+        public Configuration(ApiClient apiClient)
+        {
+
+        }
+
+        #endregion Constructors
+
+
+        #region Properties
+
+        private ApiClient _apiClient = null;
+        /// <summary>
+        /// Gets an instance of an ApiClient for this configuration
+        /// </summary>
+        public virtual ApiClient ApiClient
+        {
+            get
+            {
+                if (_apiClient == null) _apiClient = CreateApiClient();
+                return _apiClient;
+            }
+        }
+
+        private String _basePath = null;
+        /// <summary>
+        /// Gets or sets the base path for API access.
+        /// </summary>
+        public virtual string BasePath {
+            get { return _basePath; }
+            set {
+                _basePath = value;
+                // pass-through to ApiClient if it's set.
+                if(_apiClient != null) {
+                    _apiClient.RestClient.BaseUrl = new Uri(_basePath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the default header.
+        /// </summary>
+        public virtual IDictionary<string, string> DefaultHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
+        /// </summary>
+        public virtual int Timeout
+        {
+            {{#netStandard}}get { return (int)ApiClient.RestClient.Timeout.GetValueOrDefault(TimeSpan.FromSeconds(0)).TotalMilliseconds; }
+            set { ApiClient.RestClient.Timeout = TimeSpan.FromMilliseconds(value); }{{/netStandard}}{{^netStandard}}
+            get { return ApiClient.RestClient.Timeout; }
+            set { ApiClient.RestClient.Timeout = value; }{{/netStandard}}
+        }
+
+        /// <summary>
+        /// Gets or sets the HTTP user agent.
+        /// </summary>
+        /// <value>Http user agent.</value>
+        public virtual string UserAgent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username (HTTP basic authentication).
+        /// </summary>
+        /// <value>The username.</value>
+        public virtual string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password (HTTP basic authentication).
+        /// </summary>
+        /// <value>The password.</value>
+        public virtual string Password { get; set; }
+
+        /// <summary>
+        /// Gets the API key with prefix.
+        /// </summary>
+        /// <param name="apiKeyIdentifier">API key identifier (authentication scheme).</param>
+        /// <returns>API key with prefix.</returns>
+        public string GetApiKeyWithPrefix(string apiKeyIdentifier)
+        {
+            var apiKeyValue = "";
+            ApiKey.TryGetValue (apiKeyIdentifier, out apiKeyValue);
+            var apiKeyPrefix = "";
+            if (ApiKeyPrefix.TryGetValue (apiKeyIdentifier, out apiKeyPrefix))
+                return apiKeyPrefix + " " + apiKeyValue;
+            else
+                return apiKeyValue;
+        }
+
+        /// <summary>
+        /// Gets or sets the access token for OAuth2 authentication.
+        /// </summary>
+        /// <value>The access token.</value>
+        public virtual string AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the temporary folder path to store the files downloaded from the server.
+        /// </summary>
+        /// <value>Folder path.</value>
+        public virtual string TempFolderPath
+        {
+            get { return _tempFolderPath; }
+
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    _tempFolderPath = Path.GetTempPath();
+                    return;
+                }
+
+                // create the directory if it does not exist
+                if (!Directory.Exists(value))
+                {
+                    Directory.CreateDirectory(value);
+                }
+
+                // check if the path contains directory separator at the end
+                if (value[value.Length - 1] == Path.DirectorySeparatorChar)
+                {
+                    _tempFolderPath = value;
+                }
+                else
+                {
+                    _tempFolderPath = value + Path.DirectorySeparatorChar;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the date time format used when serializing in the ApiClient
+        /// By default, it's set to ISO 8601 - "o", for others see:
+        /// https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx
+        /// and https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx
+        /// No validation is done to ensure that the string you're providing is valid
+        /// </summary>
+        /// <value>The DateTimeFormat string</value>
+        public virtual string DateTimeFormat
+        {
+            get { return _dateTimeFormat; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    // Never allow a blank or null string, go back to the default
+                    _dateTimeFormat = ISO8601_DATETIME_FORMAT;
+                    return;
+                }
+
+                // Caution, no validation when you choose date time format other than ISO 8601
+                // Take a look at the above links
+                _dateTimeFormat = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the prefix (e.g. Token) of the API key based on the authentication name.
+        /// </summary>
+        /// <value>The prefix of the API key.</value>
+        public virtual IDictionary<string, string> ApiKeyPrefix
+        {
+            get { return _apiKeyPrefix; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new InvalidOperationException("ApiKeyPrefix collection may not be null.");
+                }
+                _apiKeyPrefix = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the API key based on the authentication name.
+        /// </summary>
+        /// <value>The API key.</value>
+        public virtual IDictionary<string, string> ApiKey
+        {
+            get { return _apiKey; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new InvalidOperationException("ApiKey collection may not be null.");
+                }
+                _apiKey = value;
+            }
+        }
+
+        #endregion Properties
+
+        #region Methods
+
+        /// <summary>
+        /// Add default header.
+        /// </summary>
+        /// <param name="key">Header field name.</param>
+        /// <param name="value">Header field value.</param>
+        /// <returns></returns>
+        public void AddDefaultHeader(string key, string value)
+        {
+            DefaultHeader[key] = value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ApiClient" /> based on this <see cref="Configuration" /> instance.
+        /// </summary>
+        /// <returns></returns>
+        public ApiClient CreateApiClient()
+        {
+            return new ApiClient(BasePath) { Configuration = this };
+        }
+
+
+        /// <summary>
+        /// Returns a string with essential information for debugging.
+        /// </summary>
+        public static String ToDebugReport()
+        {
+            String report = "C# SDK ({{{packageName}}}) Debug Report:\n";
+            {{^netStandard}}
+            {{^supportsUWP}}
+            report += "    OS: " + System.Environment.OSVersion + "\n";
+            report += "    .NET Framework Version: " + System.Environment.Version  + "\n";
+            {{/supportsUWP}}
+            {{/netStandard}}
+            {{#netStandard}}
+            report += "    OS: " + System.Runtime.InteropServices.RuntimeInformation.OSDescription + "\n";
+            {{/netStandard}}
+            report += "    Version of the API: {{{version}}}\n";
+            report += "    SDK Package Version: {{{packageVersion}}}\n";
+
+            return report;
+        }
+
+        /// <summary>
+        /// Add Api Key Header.
+        /// </summary>
+        /// <param name="key">Api Key name.</param>
+        /// <param name="value">Api Key value.</param>
+        /// <returns></returns>
+        public void AddApiKey(string key, string value)
+        {
+            ApiKey[key] = value;
+        }
+
+        /// <summary>
+        /// Sets the API key prefix.
+        /// </summary>
+        /// <param name="key">Api Key name.</param>
+        /// <param name="value">Api Key value.</param>
+        public void AddApiKeyPrefix(string key, string value)
+        {
+            ApiKeyPrefix[key] = value;
+        }
+
+        #endregion Methods
+    }
+}

--- a/src/PollinationSDK/Client/ApiClient.cs
+++ b/src/PollinationSDK/Client/ApiClient.cs
@@ -516,7 +516,7 @@ namespace PollinationSDK.Client
         }
 
         /// <summary>
-        /// Convert params to key/value pairs. 
+        /// Convert params to key/value pairs.
         /// Use collectionFormat to properly format lists and collections.
         /// </summary>
         /// <param name="collectionFormat">Collection format.</param>

--- a/src/PollinationSDK/Client/Configuration.cs
+++ b/src/PollinationSDK/Client/Configuration.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using RestSharp;
 
 namespace PollinationSDK.Client
 {
@@ -158,6 +159,12 @@ namespace PollinationSDK.Client
         private string _tempFolderPath = Path.GetTempPath();
 
         #endregion Private Members
+
+        #region Public Members
+
+        public TokenRepo TokenRepo;
+
+        #endregion
 
         #region Constructors
 
@@ -348,7 +355,13 @@ namespace PollinationSDK.Client
         /// Gets or sets the access token for OAuth2 authentication.
         /// </summary>
         /// <value>The access token.</value>
-        public virtual string AccessToken { get; set; }
+        public virtual string AccessToken
+        {
+            get
+            {
+                return TokenRepo.GetToken().Result;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the temporary folder path to store the files downloaded from the server.

--- a/src/PollinationSDK/Client/Configuration.cs
+++ b/src/PollinationSDK/Client/Configuration.cs
@@ -54,6 +54,7 @@ namespace PollinationSDK.Client
             string detail = null;
 
             res.TryGetValue("detail", out detail);
+            res.TryGetValue("message", out detail);
 
             if (detail != null)
             {
@@ -359,7 +360,11 @@ namespace PollinationSDK.Client
         {
             get
             {
-                return TokenRepo.GetToken().Result;
+                if (TokenRepo != null)
+                {
+                    return TokenRepo.GetToken().Result;
+                }
+                return "";
             }
         }
 

--- a/src/PollinationSDK/Helper/AuthHelper.cs
+++ b/src/PollinationSDK/Helper/AuthHelper.cs
@@ -120,7 +120,7 @@ namespace PollinationSDK
         }
 
 
-        public static async Task<AuthResult> PollinationSignInAsync(bool devEnv = false)
+        private static async Task<AuthResult> PollinationSignInAsync(bool devEnv = false)
         {
             if (!HttpListener.IsSupported)
             {

--- a/src/PollinationSDK/Helper/AuthHelper.cs
+++ b/src/PollinationSDK/Helper/AuthHelper.cs
@@ -45,7 +45,7 @@ namespace PollinationSDK
 
         private static readonly string AuthRefreshPath = "/authAPI/refreshToken";
         private static string LoginURL => string.Format(AuthURL_Base, "", AuthSignInPath);
-        private static string LoginURL_Dev => string.Format(AuthURL_Base, DevDomain, AuthRefreshPath);
+        private static string LoginURL_Dev => string.Format(AuthURL_Base, DevDomain, AuthSignInPath);
         public static string RefreshURL => string.Format(AuthURL_Base, "", AuthRefreshPath);
 
         public static string RefreshURL_Dev => string.Format(AuthURL_Base, DevDomain, AuthRefreshPath);
@@ -65,8 +65,12 @@ namespace PollinationSDK
                 {
                     Configuration.Default.BasePath = devEnv ? ApiURL_Dev : ApiURL;
 
-                    // Configuration.Default.TokenRepo = new TokenRepo()
-                    // Configuration.Default.AddDefaultHeader("Authorization", $"Bearer {authResult.IDToken}");
+                    Configuration.Default.TokenRepo = new TokenRepo(
+                        refreshURL: devEnv ? RefreshURL_Dev : RefreshURL,
+                        idToken: authResult.IDToken,
+                        expiresInSeconds: authResult.ExpiresInSeconds,
+                        refreshToken: authResult.RefreshToken
+                    );
                     Helper.CurrentUser = Helper.GetUser();
                     Helper.Logger.Information($"SignInAsync: logged in as {Helper.CurrentUser.Username}");
                 }

--- a/src/PollinationSDK/Helper/AuthHelper.cs
+++ b/src/PollinationSDK/Helper/AuthHelper.cs
@@ -12,8 +12,8 @@ namespace PollinationSDK
     public static class AuthHelper
     {
 
-        private static string LoginURL => "https://app.pollination.cloud/sdk-login";
-        private static string LoginURL_Dev => "https://app.staging.pollination.cloud/sdk-login";
+        private static string LoginURL => "https://auth.pollination.cloud/sdk-login";
+        private static string LoginURL_Dev => "https://auth.staging.pollination.cloud/sdk-login";
 
         public static string ApiURL => "https://api.pollination.cloud/";
         public static string ApiURL_Dev => "https://api.staging.pollination.cloud/";
@@ -21,7 +21,7 @@ namespace PollinationSDK
         public static async Task SignInAsync(Action ActionWhenDone = default, bool devEnv = false)
         {
             //OutputMessage = string.Empty;
-           
+
             try
             {
                 var task = PollinationSignInAsync(devEnv);
@@ -81,11 +81,12 @@ namespace PollinationSDK
 
         private static async Task<string> PollinationSignInAsync(bool devEnv = false)
         {
-            if (!HttpListener.IsSupported) {
+            if (!HttpListener.IsSupported)
+            {
                 Helper.Logger.Error($"PollinationSignInAsync: HttpListener is not supported on this system");
                 throw new ArgumentException("PollinationSignIn is not supported on this system");
             }
-               
+
             var redirectUrl = "http://localhost:8645/";
             var loginUrl = devEnv ? LoginURL_Dev : LoginURL;
 
@@ -93,7 +94,7 @@ namespace PollinationSDK
 
             try
             {
-               
+
                 listener.Prefixes.Add(redirectUrl);
                 listener.Start();
                 //listener.TimeoutManager.IdleConnection = TimeSpan.FromSeconds(30);
@@ -131,7 +132,8 @@ namespace PollinationSDK
             var response = context.Response;
 
             var returnUrl = request.RawUrl.Contains("?token=") ? request.RawUrl : request.UrlReferrer?.PathAndQuery;
-            if (string.IsNullOrEmpty(returnUrl)) {
+            if (string.IsNullOrEmpty(returnUrl))
+            {
                 Helper.Logger.Error($"PollinationSignInAsync: Failed to authorize the login: \n{request.RawUrl}");
                 throw new ArgumentException($"Failed to authorize the login: \n{request.RawUrl}");
             }

--- a/src/PollinationSDK/Helper/AuthHelper.cs
+++ b/src/PollinationSDK/Helper/AuthHelper.cs
@@ -38,8 +38,17 @@ namespace PollinationSDK
             }
         }
 
-        private static string LoginURL => "https://auth.pollination.cloud/sdk-login";
-        private static string LoginURL_Dev => "https://auth.staging.pollination.cloud/sdk-login";
+        private static readonly string DevDomain = "staging.";
+        private static readonly string AuthURL_Base = "https://auth.{0}pollination.cloud{1}";
+
+        private static readonly string AuthSignInPath = "/sdk-login";
+
+        private static readonly string AuthRefreshPath = "/authAPI/refreshToken";
+        private static string LoginURL => string.Format(AuthURL_Base, "", AuthSignInPath);
+        private static string LoginURL_Dev => string.Format(AuthURL_Base, DevDomain, AuthRefreshPath);
+        public static string RefreshURL => string.Format(AuthURL_Base, "", AuthRefreshPath);
+
+        public static string RefreshURL_Dev => string.Format(AuthURL_Base, DevDomain, AuthRefreshPath);
 
         public static string ApiURL => "https://api.pollination.cloud/";
         public static string ApiURL_Dev => "https://api.staging.pollination.cloud/";
@@ -55,7 +64,9 @@ namespace PollinationSDK
                 if (!string.IsNullOrEmpty(authResult.IDToken))
                 {
                     Configuration.Default.BasePath = devEnv ? ApiURL_Dev : ApiURL;
-                    Configuration.Default.AddDefaultHeader("Authorization", $"Bearer {authResult.IDToken}");
+
+                    // Configuration.Default.TokenRepo = new TokenRepo()
+                    // Configuration.Default.AddDefaultHeader("Authorization", $"Bearer {authResult.IDToken}");
                     Helper.CurrentUser = Helper.GetUser();
                     Helper.Logger.Information($"SignInAsync: logged in as {Helper.CurrentUser.Username}");
                 }


### PR DESCRIPTION
This should be working as long as `devEnv: true` is passed to the SignIn methods.

I put a test case [here](https://github.com/pollination/utilities/tree/csharp-auth/csharp-auth/AuthTest) that can be tested with `dotnet run` under .NET Core. By default, it waits for an hour and then tries to use one of the API calls directly which should refresh the token automatically. So, be prepared to do something else while it's waiting.

Adds:
- `TokenRepo` an object for storing and refreshing OAuth tokens in the background. 
- `AuthResult` an object for parsing the query params that are passed via browser redirect.
- Updates to `AuthHelper` to use both of these and the new sign in and refresh URLs

It works by adding a getter to the `Configuration.AccessToken` property that all of the ApiClient classes are calling. This call handles the null or empty string case. This means that the `Configuration` object needs to have a `TokenRepo` assigned explicitly outside of any constructor in order for this to work.

This is slightly different to the existing implementation which sets the `Authorization: Bearer ...` headers directly.  