### PR TITLE
fix(artifacts): Pass API and use async

### DIFF
--- a/.openapi-generator/templates/csharp/Configuration.mustache
+++ b/.openapi-generator/templates/csharp/Configuration.mustache
@@ -191,7 +191,7 @@ namespace {{packageName}}.Client
             ApiKeyPrefix = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
 
             // Setting Timeout has side effects (forces ApiClient creation).
-            Timeout = 100000;
+            Timeout = Env.HTTPTimeout;
         }
 
         /// <summary>

--- a/src/PollinationSDK/Client/Configuration.cs
+++ b/src/PollinationSDK/Client/Configuration.cs
@@ -1,4 +1,4 @@
-/* 
+/*
  * pollination-server
  *
  * Pollination Server OpenAPI Definition
@@ -197,7 +197,7 @@ namespace PollinationSDK.Client
             ApiKeyPrefix = new ConcurrentDictionary<string, string>();
 
             // Setting Timeout has side effects (forces ApiClient creation).
-            Timeout = 100000;
+            Timeout = Env.HTTPTimeout;
         }
 
         /// <summary>
@@ -303,12 +303,15 @@ namespace PollinationSDK.Client
         /// <summary>
         /// Gets or sets the base path for API access.
         /// </summary>
-        public virtual string BasePath {
+        public virtual string BasePath
+        {
             get { return _basePath; }
-            set {
+            set
+            {
                 _basePath = value;
                 // pass-through to ApiClient if it's set.
-                if(_apiClient != null) {
+                if (_apiClient != null)
+                {
                     _apiClient.RestClient.BaseUrl = new Uri(_basePath);
                 }
             }
@@ -324,7 +327,7 @@ namespace PollinationSDK.Client
         /// </summary>
         public virtual int Timeout
         {
-            
+
             get { return ApiClient.RestClient.Timeout; }
             set { ApiClient.RestClient.Timeout = value; }
         }
@@ -355,9 +358,9 @@ namespace PollinationSDK.Client
         public string GetApiKeyWithPrefix(string apiKeyIdentifier)
         {
             var apiKeyValue = "";
-            ApiKey.TryGetValue (apiKeyIdentifier, out apiKeyValue);
+            ApiKey.TryGetValue(apiKeyIdentifier, out apiKeyValue);
             var apiKeyPrefix = "";
-            if (ApiKeyPrefix.TryGetValue (apiKeyIdentifier, out apiKeyPrefix))
+            if (ApiKeyPrefix.TryGetValue(apiKeyIdentifier, out apiKeyPrefix))
                 return apiKeyPrefix + " " + apiKeyValue;
             else
                 return apiKeyValue;
@@ -505,7 +508,7 @@ namespace PollinationSDK.Client
         {
             String report = "C# SDK (PollinationSDK) Debug Report:\n";
             report += "    OS: " + System.Environment.OSVersion + "\n";
-            report += "    .NET Framework Version: " + System.Environment.Version  + "\n";
+            report += "    .NET Framework Version: " + System.Environment.Version + "\n";
             report += "    Version of the API: 0.14.0\n";
             report += "    SDK Package Version: 0.14.0\n";
 

--- a/src/PollinationSDK/Helper/Env.cs
+++ b/src/PollinationSDK/Helper/Env.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace PollinationSDK
+{
+    public static class Env
+    {
+        private static class Variable
+        {
+            public const string HTTPTimeout = "PO_HTTP_TIMEOUT";
+        }
+
+        public static int HTTPTimeout
+        {
+            get
+            {
+                int retVal = 300_000;
+                var envTimeout = Environment.GetEnvironmentVariable(Variable.HTTPTimeout);
+                if (envTimeout != null)
+                {
+                    int parseRes;
+                    int.TryParse(envTimeout, out parseRes);
+
+                    if (parseRes != null)
+                    {
+                        retVal = parseRes;
+                    }
+                }
+                return retVal;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Ups default timeout to 300s
- Adds option to override timeout with environment variable
- Sets file upload `RestClient` to use same timeout as `ApiClient`
- Adds logging for failed uploads
- Updates file upload to use `ExecuteAsync` method